### PR TITLE
Add fallback ID generator for environments without crypto.randomUUID

### DIFF
--- a/src/components/sql-editor/hooks/useEditorTabs.ts
+++ b/src/components/sql-editor/hooks/useEditorTabs.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
 import type { ObjectType } from '../ObjectTree' // Used for SchemaTab.objectType
+import { createId } from '@/lib/create-id'
 
 export interface QueryTab {
   type: 'query'
@@ -430,7 +431,7 @@ export function useEditorTabs(connectionId: string) {
         title += ' (cancelled)'
       }
       return {
-        id: crypto.randomUUID(),
+        id: createId(),
         title,
         result,
         sql: options?.sql,

--- a/src/lib/create-id.ts
+++ b/src/lib/create-id.ts
@@ -1,0 +1,11 @@
+export function createId(): string {
+  if (
+    typeof globalThis !== 'undefined' &&
+    globalThis.crypto &&
+    typeof globalThis.crypto.randomUUID === 'function'
+  ) {
+    return globalThis.crypto.randomUUID()
+  }
+
+  return `id-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+}

--- a/src/lib/staged-changes.ts
+++ b/src/lib/staged-changes.ts
@@ -1,4 +1,5 @@
 import type { ColumnMetadata } from '@/components/sql-editor/hooks/useEditorTabs'
+import { createId } from '@/lib/create-id'
 
 export type StagedChangeType = 'delete' | 'update' | 'insert'
 
@@ -138,7 +139,7 @@ export function createStagedDelete(
   }
 
   return {
-    id: crypto.randomUUID(),
+    id: createId(),
     type: 'delete',
     tables,
     rowCount: selectedRows.length,
@@ -263,7 +264,7 @@ export function createStagedInsert(
   }
 
   return {
-    id: crypto.randomUUID(),
+    id: createId(),
     type: 'insert',
     tables,
     rowCount: rows.length,
@@ -323,7 +324,7 @@ export function createStagedUpdate(
   }
 
   return {
-    id: crypto.randomUUID(),
+    id: createId(),
     type: 'update',
     tables,
     rowCount: 1,


### PR DESCRIPTION
## Summary

Replace direct `crypto.randomUUID()` usage in browser-executed code with a shared ID helper that falls back when `globalThis.crypto?.randomUUID` is unavailable.

## Changes

- add `src/lib/create-id.ts`
- replace direct UUID generation in `useEditorTabs.ts`
- replace direct UUID generation in `staged-changes.ts`

## Why

Some users running the app via Docker hit a browser-side runtime error:

```
index-03aNhJ-r.js:1468 Uncaught (in promise) TypeError: crypto.randomUUID is not a function
    at index-03aNhJ-r.js:1468:15414
    at Array.map (<anonymous>)
    at index-03aNhJ-r.js:1468:15214
    at handleExecute (index-03aNhJ-r.js:1460:723)
```

This change avoids relying on `crypto.randomUUID()` being present in all client environments.
